### PR TITLE
Make extension usable for Contao 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
   },
   "require": {
     "php": ">=5.3",
-    "contao/core": ">=3.0, <4.0",
-    "contao-community-alliance/composer-plugin": "~2.0"
+    "contao/core-bundle":"^3.0 || ^4.0",
+    "contao-community-alliance/composer-plugin":"~2.4 | ~3.0"
   },
   "replace": {
     "contao-legacy/CearchPro": "*"


### PR DESCRIPTION
Adjusted `composer.json` for Contao 4 usage.